### PR TITLE
Enhance popup animations and clean manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,8 +7,7 @@
   "default_locale": "en",
   "background": {
     "service_worker": "background/background.js",
-    "type": "module",
-    "page": "background/background.html"
+    "type": "module"
   },
   "action": { "default_popup": "webpages/popup/index.html" },
   "icons": {
@@ -58,7 +57,6 @@
   "permissions": [
     "cookies",
     "webRequest",
-    "webRequestBlocking",
     "declarativeNetRequestWithHostAccess",
     "storage",
     "contextMenus",

--- a/webpages/popup/style.css
+++ b/webpages/popup/style.css
@@ -12,6 +12,28 @@ body {
   color: var(--white-text);
 }
 
+@keyframes fade-slide-in {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+body:not(.loading) #header,
+body:not(.loading) #popups {
+  animation: fade-slide-in 0.4s ease both;
+}
+
+body.loading #header,
+body.loading #popups {
+  opacity: 0;
+  transform: translateY(-10px);
+}
+
 [v-cloak] {
   display: none !important;
 }
@@ -19,7 +41,9 @@ body {
 #header {
   display: flex;
   height: 60px;
-  background-color: var(--brand-orange);
+  background: linear-gradient(90deg, var(--brand-orange), #ff944d);
+  box-shadow: var(--large-shadow);
+  border-bottom: 1px solid var(--control-border);
 }
 .header-button {
   cursor: pointer;
@@ -57,6 +81,9 @@ body {
   background-color: var(--content-background);
   width: 100%;
   height: calc(100% - 60px);
+  border-radius: 8px;
+  box-shadow: var(--content-shadow);
+  overflow: hidden;
 }
 
 #popup-bar {


### PR DESCRIPTION
## Summary
- remove deprecated background HTML and `webRequestBlocking` permission from manifest
- add fade-slide animation to popup header and container for a polished look

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687941ba290c832584c1d3693bd95d46