### PR TITLE
Add alphabetic sprite sorting addon

### DIFF
--- a/addons/addons.json
+++ b/addons/addons.json
@@ -160,6 +160,7 @@
   "no-sprite-confirm",
   "costume-editor-shortcuts",
   "live-read-topics",
+  "sort-sprites",
 
   "// NEW ADDONS ABOVE THIS ↑↑",
   "// Note: these themes need this exact order to work properly,",

--- a/addons/sort-sprites/addon.json
+++ b/addons/sort-sprites/addon.json
@@ -1,0 +1,19 @@
+{
+  "name": "Alphabetically sort sprites",
+  "description": "Sorts sprites in the sprite pane alphabetically by name.",
+  "credits": [
+    { "name": "OpenAI Codex" }
+  ],
+  "userscripts": [
+    {
+      "url": "userscript.js",
+      "matches": ["projects"]
+    }
+  ],
+  "dynamicEnable": true,
+  "dynamicDisable": true,
+  "versionAdded": "1.44.0",
+  "tags": ["editor"],
+  "enabledByDefault": false,
+  "libraries": ["scratch-gui"]
+}

--- a/addons/sort-sprites/userscript.js
+++ b/addons/sort-sprites/userscript.js
@@ -1,0 +1,41 @@
+export default async function ({ addon }) {
+  let prevContainer = null;
+  let observer = null;
+
+  const sortSprites = (container) => {
+    if (!container) return;
+    const items = Array.from(container.children);
+    items.sort((a, b) => {
+      const nameA = a.querySelector("[class*='sprite-selector_sprite-name']").innerText.toLowerCase();
+      const nameB = b.querySelector("[class*='sprite-selector_sprite-name']").innerText.toLowerCase();
+      return nameA.localeCompare(nameB);
+    });
+    for (const item of items) {
+      container.appendChild(item);
+    }
+  };
+
+  while (true) {
+    await addon.tab.waitForElement("div[class^='sprite-selector_items-wrapper']", {
+      markAsSeen: true,
+      reduxEvents: [
+        "scratch-gui/mode/SET_PLAYER",
+        "fontsLoaded/SET_FONTS_LOADED",
+        "scratch-gui/locales/SELECT_LOCALE",
+        "scratch-gui/sprites/ADD_SPRITE",
+        "scratch-gui/sprites/DELETE_SPRITE",
+        "scratch-gui/sprites/UPDATE_SPRITE_NAME"
+      ],
+      reduxCondition: (state) => !state.scratchGui.mode.isPlayerOnly,
+    });
+
+    const container = document.querySelector("div[class^='sprite-selector_items-wrapper']");
+    if (container && container !== prevContainer) {
+      if (observer) observer.disconnect();
+      observer = new MutationObserver(() => sortSprites(container));
+      observer.observe(container, { childList: true });
+      prevContainer = container;
+    }
+    sortSprites(container);
+  }
+}


### PR DESCRIPTION
## Summary
- add addon that sorts sprites alphabetically in the sprite pane

## Testing
- `npx eslint . --config eslint.config.mjs` *(fails: cannot download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687947ef57308325801e4baea8838994